### PR TITLE
Add viewport meta tag for responsive design

### DIFF
--- a/iching 2.html
+++ b/iching 2.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Reloj I Ching — Horror Pixel</title>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles.css">


### PR DESCRIPTION
## Summary
- add viewport meta tag before title to improve layout on mobile devices

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898064b9618832aab3db162cf8311a3