### PR TITLE
refactor: convert clock script into module

### DIFF
--- a/clock.js
+++ b/clock.js
@@ -122,4 +122,7 @@ function loop(){
   if(!paused) draw();
   requestAnimationFrame(loop);
 }
+
+export { mapToHexagram, bitsFromIndexBinary };
+
 loop();

--- a/iching 2.html
+++ b/iching 2.html
@@ -8,6 +8,6 @@
 </head>
 <body>
 <canvas id="game"></canvas>
-<script src="clock.js"></script>
+<script type="module" src="clock.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor clock logic into an ES module
- expose mapToHexagram and bitsFromIndexBinary as public API
- adjust HTML to load module instead of global script

## Testing
- `node --experimental-default-type=module --check clock.js`
- `npm test` *(fails: enoent ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689806524dbc832a9360ba62b9980083